### PR TITLE
ewma over reference values

### DIFF
--- a/cimetrics/plot.py
+++ b/cimetrics/plot.py
@@ -64,10 +64,10 @@ class Metrics(object):
 
     def ewma_all_for_branch(self, branch):
         def values_from(d):
-            return {k: v.get('value') for k, v in d.items()}
+            return {k: v.get("value") for k, v in d.items()}
 
         def values(d):
-            return {k: {'value': v} for k, v in d.items()}
+            return {k: {"value": v} for k, v in d.items()}
 
         query = {"branch": branch}
         res = self.col.find(query)

--- a/cimetrics/plot.py
+++ b/cimetrics/plot.py
@@ -67,7 +67,7 @@ class Metrics(object):
         res = self.col.find(query)
         res = res.sort([("created", pymongo.ASCENDING)]).limit(30)
         df = pandas.DataFrame.from_records([r["metrics"] for r in res])
-        ewr = df.ewm(span=5).mean().tail(1).to_dict('index')
+        ewr = df.ewm(span=5).mean().tail(1).to_dict("index")
         metrics = {}
         for data in ewr.values():
             metrics.update(data["metrics"])

--- a/cimetrics/plot.py
+++ b/cimetrics/plot.py
@@ -71,7 +71,7 @@ class Metrics(object):
 
         query = {"branch": branch}
         res = self.col.find(query)
-        res = res.sort([("created", pymongo.ASCENDING)]).limit(30)
+        res = res.sort([("created", pymongo.ASCENDING)]).limit(100)
         df = pandas.DataFrame.from_records([values_from(r["metrics"]) for r in res])
         ewr = df.ewm(span=5).mean().tail(1).to_dict("index")
         metrics = {}

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,6 @@ setup(
         "matplotlib",
         "numpy",
         "black",
+        "pandas"
     ],
 )


### PR DESCRIPTION
Adding #32

There are two problems that this does not solve:

1. Our current data format in Mongo is awkward when getting in/out of pandas. I suspect we're only going to be doing more of that (#34, future plotting work...), and the number of angry users caused by the compatibility break is going to be small still, so we should seize the opportunity.
2. If plotting runs in the middle of a master build publishing its metrics, a number of metrics will be wrongly labeled as new. That's because it is currently impossible to find out if a build is finished, or if some metrics have simply been deleted from it.

I say we just open tickets for those because we don't really have time to figure them out at the moment. For 2. I suspect the answer will be, we have to write a termination document of some sort effectively saying "build id foo is complete, no more metrics will be published for it". Better ideas are welcome.