### PR TITLE
Description content type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     version="0.2.6",
     description="Lightweight python module to track crucial metrics",
     long_description=long_description,
+    long_description_content_type='text/markdown',
     url="https://github.com/jumaffre/cimetrics",
     author="Julien Maffre",
     classifiers=[


### PR DESCRIPTION
I tried to update `0.2.6` locally but it seems that the default format is `.rst`. This should fix the issue.

Note that as expected, we cannot push the same version twice to PyPI so we will see this in action for the next release.