### PR TITLE
Capture build number

### DIFF
--- a/cimetrics/upload.py
+++ b/cimetrics/upload.py
@@ -53,6 +53,7 @@ class Metrics(object):
         doc = {
             "created": datetime.datetime.now(),
             "build_id": self.env.build_id,
+            "build_number": self.env.build_number,
             "branch": self.env.branch,
             "is_pr": self.env.is_pr,
             "commit": self.env.commit,


### PR DESCRIPTION
For some reason I thought we did this already, and we could just display them in xticks. Apparently not. So let's do it.