### PR TITLE
Map build numbers, remove deprecated view option

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ The last step is to create a new `metrics.yml` configuration file at the root of
 ```yaml
 db: 'metrics'
 collection: 'metrics_performance'
-view: 'trend'
 ```
 
 That's it! The next time you create a Pull Request, your CI will automatically store your metrics and publish a graph comparing your metrics against the same metrics on the branch you are merging to. Note that the cimetrics PR comment is updated for each subsequent build.

--- a/cimetrics/env.py
+++ b/cimetrics/env.py
@@ -57,10 +57,6 @@ class Env(object):
         return self.cfg["collection"]
 
     @property
-    def view(self) -> str:
-        return self.cfg.get("view", "default")
-
-    @property
     def columns(self) -> int:
         return self.cfg.get("columns", 2)
 

--- a/cimetrics/plot.py
+++ b/cimetrics/plot.py
@@ -347,7 +347,8 @@ def trend_view(env, tgt_only=False):
         xticks = [0] + interesting_ticks + [len(tgt_raw) - 1]
         xticks_labels = [fancy_date(tick_map[tgt_raw.index.values[i]]) for i in xticks]
 
-        plt.xticks(rotation=-30, ha="left")
+        if tgt_only:
+            plt.xticks(rotation=-30, ha="left")
         ax.set_xticks(xticks)
         ax.set_xticklabels(
             xticks_labels, {"fontsize": font_size.XTICKS},

--- a/cimetrics/plot.py
+++ b/cimetrics/plot.py
@@ -234,8 +234,13 @@ def trend_view(env, tgt_only=False):
                     interesting_ticks.append(anomaly)
                     ax.axvline(x=anomaly, color=Color.BAD, linestyle=":", linewidth=0.5)
                     ev = tgt_ewma[col].iloc[anomaly]
-                    ax.annotate(
-                        ticklabel_format(ev) % ev, xy=(anomaly, ymax), color=Color.BAD
+                    ax.text(
+                        anomaly,
+                        ymax,
+                        ticklabel_format(ev) % ev,
+                        color=Color.BAD,
+                        rotation=-30,
+                        ha="right",
                     )
 
         if not tgt_only:
@@ -334,6 +339,7 @@ def trend_view(env, tgt_only=False):
         xticks = [0] + interesting_ticks + [len(tgt_raw) - 1]
         xticks_labels = [tick_map[tgt_raw.index.values[i]] for i in xticks]
 
+        plt.xticks(rotation=-30, ha="left")
         ax.set_xticks(xticks)
         ax.set_xticklabels(
             xticks_labels, {"fontsize": font_size.XTICKS},

--- a/cimetrics/plot.py
+++ b/cimetrics/plot.py
@@ -318,12 +318,16 @@ def trend_view(env, tgt_only=False):
 
         fmt = ticklabel_format(yt[0])
         ax.yaxis.set_major_formatter(mtick.FormatStrFormatter(fmt))
+        padding = {}
+        if tgt_only:
+            padding["pad"] = 14
         ax.set_title(
             col.strip("^").strip(),
             loc="left",
             fontdict={"fontweight": "bold"},
             color="dimgray",
             fontsize=font_size.TITLE,
+            **padding,
         )
         ax.tick_params(axis="y", which="both", color=Color.TICK)
         ax.tick_params(axis="x", which="both", color=Color.TICK)

--- a/cimetrics/plot.py
+++ b/cimetrics/plot.py
@@ -349,6 +349,8 @@ def trend_view(env, tgt_only=False):
 
         if tgt_only:
             plt.xticks(rotation=-30, ha="left")
+        else:
+            plt.xticks(ha="left")
         ax.set_xticks(xticks)
         ax.set_xticklabels(
             xticks_labels, {"fontsize": font_size.XTICKS},

--- a/cimetrics/plot.py
+++ b/cimetrics/plot.py
@@ -56,6 +56,10 @@ def ticklabel_format(value):
         return "%.1e"
 
 
+def fancy_date(ds):
+    return f"$_{{{ds[:4]}}}${ds[4:]}"
+
+
 class Metrics(object):
     def __init__(self, env):
         if env is None:
@@ -337,7 +341,7 @@ def trend_view(env, tgt_only=False):
             plt.setp(ax.spines.values(), visible=False)
 
         xticks = [0] + interesting_ticks + [len(tgt_raw) - 1]
-        xticks_labels = [tick_map[tgt_raw.index.values[i]] for i in xticks]
+        xticks_labels = [fancy_date(tick_map[tgt_raw.index.values[i]]) for i in xticks]
 
         plt.xticks(rotation=-30, ha="left")
         ax.set_xticks(xticks)

--- a/metrics.yml
+++ b/metrics.yml
@@ -1,6 +1,5 @@
 db: 'metrics'
 collection: 'metrics_my_app'
-view: "trend"
 columns: 3
 monitoring_issue: 73
 span: 50


### PR DESCRIPTION
Address the second item in https://github.com/jumaffre/cimetrics/issues/73

Also, drive-by removal of the view selector in options, since we've long given up on the alternative to trend (can't even remember what it was called!).

~~There's something to be done about preventing tick labels from overlapping, but I don't know what yet. Probably at least some rotation, although that's not a silver bullet.~~
Rotation helps some, see CCF views. Not perfect but pretty good I think.