### PR TITLE
Slightly more visible and more compact ticks

### DIFF
--- a/cimetrics/plot.py
+++ b/cimetrics/plot.py
@@ -334,8 +334,22 @@ def trend_view(env, tgt_only=False):
             fontsize=font_size.TITLE,
             **padding,
         )
-        ax.tick_params(axis="y", which="both", color=Color.TICK)
-        ax.tick_params(axis="x", which="both", color=Color.TICK)
+        ax.tick_params(
+            axis="y",
+            which="both",
+            color=Color.TARGET_TREND,
+            length=3,
+            width=1,
+            direction="in",
+        )
+        ax.tick_params(
+            axis="x",
+            which="both",
+            color=Color.TARGET_TREND,
+            length=3,
+            width=1,
+            direction="in",
+        )
         # Match tick colors with series they belong to
         tls = ax.yaxis.get_ticklabels()
         if not tgt_only:

--- a/cimetrics/plot.py
+++ b/cimetrics/plot.py
@@ -344,10 +344,7 @@ def trend_view(env, tgt_only=False):
                 direction="in",
             )
         else:
-            ax.tick_params(
-                axis="y",
-                bottom=False
-            )
+            ax.tick_params(axis="y", bottom=False)
         ax.tick_params(
             axis="x",
             which="both",

--- a/cimetrics/plot.py
+++ b/cimetrics/plot.py
@@ -344,7 +344,7 @@ def trend_view(env, tgt_only=False):
                 direction="in",
             )
         else:
-            ax.tick_params(axis="y", bottom=False)
+            ax.tick_params(axis="y", right=False)
         ax.tick_params(
             axis="x",
             which="both",

--- a/cimetrics/plot.py
+++ b/cimetrics/plot.py
@@ -334,14 +334,20 @@ def trend_view(env, tgt_only=False):
             fontsize=font_size.TITLE,
             **padding,
         )
-        ax.tick_params(
-            axis="y",
-            which="both",
-            color=Color.TARGET_TREND,
-            length=3,
-            width=1,
-            direction="in",
-        )
+        if tgt_only:
+            ax.tick_params(
+                axis="y",
+                which="both",
+                color=Color.TARGET_TREND,
+                length=3,
+                width=1,
+                direction="in",
+            )
+        else:
+            ax.tick_params(
+                axis="y",
+                bottom=False
+            )
         ax.tick_params(
             axis="x",
             which="both",


### PR DESCRIPTION
x ticks are thicker, darker, moved up in both modes.
Target only has the same for y ticks, but in branch mode, y ticks are removed, since they're display at the start/end of the change arrow.