### PR TITLE
Remove dev tools from pkg dependencies

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -21,6 +21,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .
+        pip install -r dev-requirements.txt
     - name: Check format with black
       run: |
         black --check cimetrics

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,9 @@ steps:
 - script: pip install .
   displayName: 'Install library'
 
+- script: pip install -r dev-requirements.txt
+  displayName: 'Install dev dependencies'
+
 - script: black --check cimetrics
   displayName: 'Check code format'
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,2 @@
+black
+mypy

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 
 from setuptools import setup
 from os import path
-from subprocess import run
 
 here = path.abspath(path.dirname(__file__))
 
@@ -36,9 +35,7 @@ setup(
         "requests",
         "matplotlib",
         "numpy",
-        "black",
         "pandas",
         "adtk",
-        "mypy",
     ],
 )


### PR DESCRIPTION
Consumers shouldn't pull in tools not used in the package itself.