### PR TITLE
Azure storage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,6 +51,8 @@ steps:
 - script: python -m cimetrics.github_pr
   env:
     GITHUB_TOKEN: $(GITHUB_TOKEN)
+    AZURE_BLOB_URL: $(AZURE_BLOB_URL)
+    AZURE_WEB_URL: $(AZURE_WEB_URL)
   displayName: 'Post metrics graphs as PR comment'
 
 - task: PublishBuildArtifacts@1

--- a/cimetrics/env.py
+++ b/cimetrics/env.py
@@ -197,6 +197,10 @@ class AzurePipelinesEnv(GitEnv):
     def repo_id(self) -> str:
         return os.environ["BUILD_REPOSITORY_ID"]
 
+    @property
+    def repo_name(self) -> str:
+        return os.environ["BUILD_REPOSITORY_NAME"]
+
     def build_url_by_id(self, build_id) -> str:
         prefix = os.environ["SYSTEM_TEAMFOUNDATIONSERVERURI"]
         project = os.environ["SYSTEM_TEAMPROJECT"]

--- a/cimetrics/github_pr.py
+++ b/cimetrics/github_pr.py
@@ -72,7 +72,7 @@ class GithubPRPublisher(object):
 
     def upload_image_as_blob(self, contents):
         service = BlobServiceClient(account_url=AZURE_BLOB_URL)
-        name = f"plot-{self.env.pull_request_id}.png"
+        name = f"plot-{self.env.repo_root}-{self.env.pull_request_id}.png"
         blob = service.get_blob_client(container="$web", blob=name)
         blob.upload_blob(
             contents,

--- a/cimetrics/github_pr.py
+++ b/cimetrics/github_pr.py
@@ -72,7 +72,7 @@ class GithubPRPublisher(object):
 
     def upload_image_as_blob(self, contents):
         service = BlobServiceClient(account_url=AZURE_BLOB_URL)
-        name = f"image{self.env.pull_request_id}.png"
+        name = f"ciplot-{self.env.pull_request_id}.png"
         blob = service.get_blob_client(container="$web", blob=name)
         blob.upload_blob(
             contents,

--- a/cimetrics/github_pr.py
+++ b/cimetrics/github_pr.py
@@ -8,6 +8,7 @@ import base64
 import datetime
 import os
 from azure.storage.blob import BlobServiceClient
+import urllib.parse
 
 from cimetrics.env import get_env
 
@@ -72,7 +73,7 @@ class GithubPRPublisher(object):
 
     def upload_image_as_blob(self, contents):
         service = BlobServiceClient(account_url=AZURE_BLOB_URL)
-        name = f"image{datetime.datetime.now()}.png"
+        name = urllib.parse.quote(f"image{datetime.datetime.now()}.png")
         blob = service.get_blob_client(container="$web", blob=name)
         blob.upload_blob(contents)
         return f"{AZURE_WEB_URL}/{name}"

--- a/cimetrics/github_pr.py
+++ b/cimetrics/github_pr.py
@@ -8,7 +8,6 @@ import base64
 import datetime
 import os
 from azure.storage.blob import BlobServiceClient
-import urllib.parse
 
 from cimetrics.env import get_env
 
@@ -73,7 +72,7 @@ class GithubPRPublisher(object):
 
     def upload_image_as_blob(self, contents):
         service = BlobServiceClient(account_url=AZURE_BLOB_URL)
-        name = urllib.parse.quote(f"image{datetime.datetime.now()}.png")
+        name = f"image{self.env.pull_request_id}.png"
         blob = service.get_blob_client(container="$web", blob=name)
         blob.upload_blob(contents)
         return f"{AZURE_WEB_URL}/{name}"

--- a/cimetrics/github_pr.py
+++ b/cimetrics/github_pr.py
@@ -16,8 +16,9 @@ IMAGE_BRANCH_NAME = "cimetrics"
 IMAGE_PATH = "_cimetrics/diff.png"
 COMMENT_PATH = "_cimetrics/diff.txt"
 
-AZURE_BLOB_URL=os.getenv("AZURE_BLOB_URL")
-AZURE_WEB_URL=os.getenv("AZURE_WEB_URL")
+AZURE_BLOB_URL = os.getenv("AZURE_BLOB_URL")
+AZURE_WEB_URL = os.getenv("AZURE_WEB_URL")
+
 
 class GithubPRPublisher(object):
     def __init__(self):

--- a/cimetrics/github_pr.py
+++ b/cimetrics/github_pr.py
@@ -72,7 +72,7 @@ class GithubPRPublisher(object):
 
     def upload_image_as_blob(self, contents):
         service = BlobServiceClient(account_url=AZURE_BLOB_URL)
-        name = f"ciplot-{self.env.pull_request_id}.png"
+        name = f"plot-{self.env.pull_request_id}.png"
         blob = service.get_blob_client(container="$web", blob=name)
         blob.upload_blob(
             contents,

--- a/cimetrics/github_pr.py
+++ b/cimetrics/github_pr.py
@@ -75,7 +75,7 @@ class GithubPRPublisher(object):
         name = f"image{datetime.datetime.now()}.png"
         blob = service.get_blob_client(container="$web", blob=name)
         blob.upload_blob(contents)
-        return f"{AZURE_WEB_URL}/name"
+        return f"{AZURE_WEB_URL}/{name}"
 
     def first_self_comment(self):
         rep = requests.get(

--- a/cimetrics/github_pr.py
+++ b/cimetrics/github_pr.py
@@ -72,7 +72,7 @@ class GithubPRPublisher(object):
 
     def upload_image_as_blob(self, contents):
         service = BlobServiceClient(account_url=AZURE_BLOB_URL)
-        name = f"plot-{self.env.repo_name}-{self.env.pull_request_id}.png"
+        name = f"plot-{self.env.repo_name.replace('/', '-')}-{self.env.pull_request_id}.png"
         blob = service.get_blob_client(container="$web", blob=name)
         blob.upload_blob(
             contents,

--- a/cimetrics/github_pr.py
+++ b/cimetrics/github_pr.py
@@ -7,7 +7,7 @@ import sys
 import base64
 import datetime
 import os
-from azure.storage.blob import BlobServiceClient
+from azure.storage.blob import BlobServiceClient, ContentSettings
 
 from cimetrics.env import get_env
 
@@ -74,7 +74,11 @@ class GithubPRPublisher(object):
         service = BlobServiceClient(account_url=AZURE_BLOB_URL)
         name = f"image{self.env.pull_request_id}.png"
         blob = service.get_blob_client(container="$web", blob=name)
-        blob.upload_blob(contents)
+        blob.upload_blob(
+            contents,
+            overwrite=True,
+            content_settings=ContentSettings(content_type="image/png"),
+        )
         return f"{AZURE_WEB_URL}/{name}"
 
     def first_self_comment(self):

--- a/cimetrics/github_pr.py
+++ b/cimetrics/github_pr.py
@@ -133,7 +133,7 @@ if __name__ == "__main__":
         comment = comment_file.read()
 
     if AZURE_BLOB_URL and AZURE_WEB_URL:
-        image_url = publisher.uplo(str(encoded_image.decode()))
+        image_url = publisher.upload_image(str(encoded_image.decode()))
     else:
         image_url = publisher.upload_image_as_blob(raw_image)
     publisher.publish_comment(image_url, comment)

--- a/cimetrics/github_pr.py
+++ b/cimetrics/github_pr.py
@@ -72,7 +72,7 @@ class GithubPRPublisher(object):
 
     def upload_image_as_blob(self, contents):
         service = BlobServiceClient(account_url=AZURE_BLOB_URL)
-        name = f"plot-{self.env.repo_root}-{self.env.pull_request_id}.png"
+        name = f"plot-{self.env.repo_name}-{self.env.pull_request_id}.png"
         blob = service.get_blob_client(container="$web", blob=name)
         blob.upload_blob(
             contents,

--- a/cimetrics/github_pr.py
+++ b/cimetrics/github_pr.py
@@ -133,7 +133,7 @@ if __name__ == "__main__":
         comment = comment_file.read()
 
     if AZURE_BLOB_URL and AZURE_WEB_URL:
-        image_url = publisher.upload_image(str(encoded_image.decode()))
-    else:
         image_url = publisher.upload_image_as_blob(raw_image)
+    else:
+        image_url = publisher.upload_image(str(encoded_image.decode()))
     publisher.publish_comment(image_url, comment)

--- a/cimetrics/github_pr.py
+++ b/cimetrics/github_pr.py
@@ -77,7 +77,9 @@ class GithubPRPublisher(object):
         blob.upload_blob(
             contents,
             overwrite=True,
-            content_settings=ContentSettings(content_type="image/png"),
+            content_settings=ContentSettings(
+                content_type="image/png", cache_control="no-cache"
+            ),
         )
         return f"{AZURE_WEB_URL}/{name}"
 

--- a/cimetrics/plot.py
+++ b/cimetrics/plot.py
@@ -39,7 +39,7 @@ class SmallFontSize:
 class StandardFontSize:
     XTICKS = 4
     YTICKS = 4
-    TITLE = 4.5
+    TITLE = 5
     DEFAULT = 4
 
 

--- a/cimetrics/plot.py
+++ b/cimetrics/plot.py
@@ -39,7 +39,7 @@ class SmallFontSize:
 class StandardFontSize:
     XTICKS = 4
     YTICKS = 4
-    TITLE = 5
+    TITLE = 4.5
     DEFAULT = 4
 
 

--- a/cimetrics/plot.py
+++ b/cimetrics/plot.py
@@ -36,8 +36,11 @@ class SmallFontSize:
     DEFAULT = 4
 
 
-class StandardFontSize(SmallFontSize):
-    pass
+class StandardFontSize:
+    XTICKS = 4
+    YTICKS = 4
+    TITLE = 6
+    DEFAULT = 4
 
 
 def ticklabel_format(value):

--- a/cimetrics/plot.py
+++ b/cimetrics/plot.py
@@ -298,8 +298,9 @@ def trend_view(env, tgt_only=False):
                         [bx, bx],
                         [lewm, by],
                         color=good_col if by < lewm else bad_col,
-                        linestyle=":",
+                        linestyle="-",
                         linewidth=1,
+                        alpha=0.3,
                     )
 
                 if col in tgt_ewma:

--- a/cimetrics/plot.py
+++ b/cimetrics/plot.py
@@ -39,7 +39,7 @@ class SmallFontSize:
 class StandardFontSize:
     XTICKS = 4
     YTICKS = 4
-    TITLE = 6
+    TITLE = 5
     DEFAULT = 4
 
 

--- a/setup.py
+++ b/setup.py
@@ -37,5 +37,6 @@ setup(
         "numpy",
         "pandas",
         "adtk",
+        "azure-storage-blob"
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="cimetrics",
-    version="0.2.27",
+    version="0.2.28",
     description="Lightweight python module to track crucial metrics",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Spawned off of #103, the idea is to:

1. stop using a custom branch in the repo for storage
2. curb growth by storing runs for the same PR/monitoring issue in place

I was initially worried about the implications of 2. with concurrent jobs, but it seems to me that with batching/autoCancel it is in fact a non issue. If this turns out not to be the case, I suppose we can look at using ETags. I've added this as a side-option for now, but my intention is for this to replace the branch-based storage altogether.

Assuming we're happy with this, the plan is to:

1. release, enable in CCF
2. remove the repo branch code path, which I don't think we seriously want to continue using

I don't think it's worth spending time migrating old PRs, but we could keep the branch around for say, six months, before dropping it. Also pinging @eddyashton for review/feedback.