### PR TITLE
Pin `PyMongo`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     packages=["cimetrics"],
     python_requires=">=3.6",
     install_requires=[
-        "pymongo",
+        "pymongo<4,>=3.12.1",  # 4.0 has wire incompatibility with CosmosDB
         "pyyaml",
         "gitpython",
         "requests",


### PR DESCRIPTION
PyMongo update to 4.0 triggers the following exception when running `python app/main.py`: 
```
Traceback (most recent call last):
  File "app/main.py", line 32, in <module>
    m.put("New metric (U)", results["new_metric"])
  File "/usr/lib/python3.8/contextlib.py", line 120, in __exit__
    next(self.gen)
  File "/home/jumaffre/git/cimetrics/cimetrics/upload.py", line 79, in metrics
    m.publish()
  File "/home/jumaffre/git/cimetrics/cimetrics/upload.py", line 72, in publish
    coll.insert_one(doc)
  File "/home/jumaffre/git/cimetrics/env/lib/python3.8/site-packages/pymongo/collection.py", line 524, in insert_one
    self._insert_one(
  File "/home/jumaffre/git/cimetrics/env/lib/python3.8/site-packages/pymongo/collection.py", line 474, in _insert_one
    self.__database.client._retryable_write(
  File "/home/jumaffre/git/cimetrics/env/lib/python3.8/site-packages/pymongo/mongo_client.py", line 1340, in _retryable_write
    return self._retry_with_session(retryable, func, s, None)
  File "/home/jumaffre/git/cimetrics/env/lib/python3.8/site-packages/pymongo/mongo_client.py", line 1229, in _retry_with_session
    return self._retry_internal(retryable, func, session, bulk)
  File "/home/jumaffre/git/cimetrics/env/lib/python3.8/site-packages/pymongo/mongo_client.py", line 1249, in _retry_internal
    server = self._select_server(writable_server_selector, session)
  File "/home/jumaffre/git/cimetrics/env/lib/python3.8/site-packages/pymongo/mongo_client.py", line 1137, in _select_server
    server = topology.select_server(server_selector)
  File "/home/jumaffre/git/cimetrics/env/lib/python3.8/site-packages/pymongo/topology.py", line 242, in select_server
    servers = self.select_servers(
  File "/home/jumaffre/git/cimetrics/env/lib/python3.8/site-packages/pymongo/topology.py", line 200, in select_servers
    server_descriptions = self._select_servers_loop(
  File "/home/jumaffre/git/cimetrics/env/lib/python3.8/site-packages/pymongo/topology.py", line 234, in _select_servers_loop
    self._description.check_compatible()
  File "/home/jumaffre/git/cimetrics/env/lib/python3.8/site-packages/pymongo/topology_description.py", line 130, in check_compatible
    raise ConfigurationError(self._incompatible_err)
pymongo.errors.ConfigurationError: Server at cdb-ms-prod-eastus1-fd3.documents.azure.com:10255 reports wire version 2, but this version of PyMongo requires at least 6 (MongoDB 3.6)

```