### PR TITLE
Install wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     packages=["cimetrics"],
     python_requires=">=3.6",
     install_requires=[
+        "wheel",
         "pymongo",
         "pyyaml",
         "gitpython",


### PR DESCRIPTION
Fixes `error: invalid command 'bdist_wheel'` when installing.

e.g. from https://github.com/microsoft/LSKV/actions/runs/3446163543/jobs/5750731840 in the `Build App` step